### PR TITLE
use fastq.simpleName to get sample name

### DIFF
--- a/modules.nf
+++ b/modules.nf
@@ -77,7 +77,7 @@ mageck test \
     -c "\$(cat ${control_samples})" \
     -n "${params.output_prefix}" \
     --control-sgrna ${ntc_list} \
-    --norm-method control
+    --norm-method total
 
 ls -lahtr
 """

--- a/modules.nf
+++ b/modules.nf
@@ -15,21 +15,14 @@ process mageck {
         file "*.count.txt"
 
     script:
-"""/bin/bash
+    sample_name = "${fastq.simpleName}"
+    """
 
-set -Eeuo pipefail
+    echo FASTQ file is ${fastq.name}
+    echo Sample name is ${sample_name}
 
-# Parse the name of the sample from the name of the FASTQ file
-SAMPLE_NAME="${fastq.name}"
-for suffix in ${params.suffix_list}; do
-    SAMPLE_NAME=\$(echo \$SAMPLE_NAME | sed "s/.\$suffix\$//")
-done
-
-echo FASTQ file is ${fastq.name}
-echo Sample name is \$SAMPLE_NAME
-
-mageck count -l ${library} -n \$SAMPLE_NAME --sample-label \$SAMPLE_NAME  --fastq ${fastq}
-"""
+    mageck count -l ${library} -n ${sample_name} --sample-label ${sample_name}  --fastq ${fastq}
+    """
 
 }
 


### PR DESCRIPTION
Related to https://github.com/FredHutch/crispr-screen-nf/pull/2, uses [`.simpleName`](https://www.nextflow.io/docs/latest/script.html#check-file-attributes) to get the sample id without `.fastq.gz`