### PR TITLE
Update adapter trimming - fix PCA bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,18 @@ expected by this particular workflow is CSV, with the three column headers named
 ## Read Trimming
 
 After generating NGS data from the sgRNA libraries used in this screen, the user
-must specify the number of bases which need to be trimmed from the beginning (5')
-and end (3') of each read in order to yield the exact region of the sgRNA sequence.
-Depending on the read length and library design, these values may vary between
-experiments. The default values are to trim 32bp from the beginning of each read,
-and 8bp from the end. Note that the number of bases trimmed from the end of the
-read is indicated with a negative number (as `-8`).
+must specify the best way to trim adapter sequences away from the sgRNA guides.
+The two options available using this workflow are (a) trimming a fixed number of
+bases from the 5' of each read, and then trimming down to a fixed number of bases,
+or (b) using a known adapter sequence to remove 5' adapters, and then trimming
+down to a fixed number of bases. In either case, the reads which are output by
+the trimming step will all have the same length (which should correspond to the
+length of the sgRNA guides).
+
+To trim a fixed number of bases from the 5' of each read, use the `trim_5_prime`
+parameter. To trim a known 5' adapter sequence, use the `adapter_5_prime` parameter.
+Details on sequence-based 5' adapter trimming can be found
+[here](https://cutadapt.readthedocs.io/en/stable/guide.html#regular-5-adapters).
 
 ## Prerequisites
 
@@ -56,8 +62,9 @@ Required Arguments:
                             As described at https://sourceforge.net/p/mageck/wiki/input/
     --output            Path to output directory
 
-    --trim_5_prime      Amount to trim from 5 prime end (default: 32)
-    --trim_3_prime      Amount to trim from 3 prime end (default: -8)
+    --insert_length     Length of sgRNA guides (default: 20)
+    --trim_5_prime      Number of bases to trim from the 5' of each read (default: 0)
+    --adapter_5_prime   (optional) Sequence of 5' adapter to be trimmed from each read
     --organism          Organism string provided for MAGeCK-Flute (default: hsa)
     --scale_cutoff      Parameter 'scale_cutoff' for MAGeCK-Flute (default: 1)
     --gmt               Pathway GMT File

--- a/main.nf
+++ b/main.nf
@@ -3,25 +3,6 @@
 // Using DSL-2
 nextflow.enable.dsl=2
 
-// Set default parameters
-params.help = false
-params.scale_cutoff = 1
-params.trim_3_prime = -8
-params.trim_5_prime = 32
-
-// List of extensions to be remove to determine sample name
-params.suffix_list = "trimmed gz fq fastq fna fasta"
-
-// Containers
-params.container__pandas = "quay.io/fhcrc-microbiome/python-pandas:v1.2.1_latest"
-params.container__fastqc = "quay.io/biocontainers/fastqc:0.11.9--hdfd78af_1"
-params.container__multiqc = "quay.io/biocontainers/multiqc:1.11--pyhdfd78af_0"
-params.container__cutadapt = "quay.io/biocontainers/cutadapt:3.4--py37h73a75cf_1"
-params.container__mageck = "quay.io/biocontainers/mageck:0.5.9.4--py38h8c62d01_1"
-params.container__mageckflute = "quay.io/biocontainers/bioconductor-mageckflute:1.12.0--r41hdfd78af_0"
-params.container__mageckvispr = "quay.io/biocontainers/mageck-vispr:0.5.6--py_0"
-params.container__rmd = "rocker/r-rmd:latest"
-
 // Import the modules
 include {
     trim as trim_treatment;

--- a/main.nf
+++ b/main.nf
@@ -65,8 +65,9 @@ def validate(params) {
                                     As described at https://sourceforge.net/p/mageck/wiki/input/
             --output            Path to output directory
 
-            --trim_5_prime      Amount to trim from 5 prime end (default: 32)
-            --trim_3_prime      Amount to trim from 3 prime end (default: -8)
+            --insert_length     Length of sgRNA guides (default: 20)
+            --trim_5_prime      Number of bases to trim from the 5' of each read (default: 0)
+            --adapter_5_prime   (optional) Sequence of 5' adapter to be trimmed from each read
             --organism          Organism string provided for MAGeCK-Flute (default: hsa)
             --scale_cutoff      Parameter 'scale_cutoff' for MAGeCK-Flute (default: 1)
             --gmt               Pathway GMT File

--- a/main.nf
+++ b/main.nf
@@ -24,9 +24,9 @@ params.container__rmd = "rocker/r-rmd:latest"
 
 // Import the modules
 include {
-    cutadapt_trim as cutadapt_trim_treatment;
-    cutadapt_trim as cutadapt_trim_control;
-} from './module.cutadapt'
+    trim as trim_treatment;
+    trim as trim_control;
+} from './modules/cutadapt'
 
 include {
     mageck_count as mageck_count_treatment;
@@ -127,13 +127,13 @@ workflow {
 
     // Process : Cutadapt Trim
     // Remove Extra Adaptor Sequences From Reads
-    cutadapt_trim_treatment(Channel_Fastq_Treatment, 'cutadapt/trim/treatment')
-    cutadapt_trim_control(Channel_Fastq_Control, 'cutadapt/trim/control')
+    trim_treatment(Channel_Fastq_Treatment, 'cutadapt/trim/treatment')
+    trim_control(Channel_Fastq_Control, 'cutadapt/trim/control')
 
     // Process : Mageck Count
     // Map the raw FASTQ data to reference library file and count the reads for each sgRNA
-    mageck_count_treatment(cutadapt_trim_treatment.out.combine(Channel_Library), 'mageck/count/treatment')
-    mageck_count_control(cutadapt_trim_control.out.combine(Channel_Library), 'mageck/count/control')
+    mageck_count_treatment(trim_treatment.out.combine(Channel_Library), 'mageck/count/treatment')
+    mageck_count_control(trim_control.out.combine(Channel_Library), 'mageck/count/control')
 
     // Process : Mageck Merge
     // Concat All Count Data

--- a/modules/cutadapt.nf
+++ b/modules/cutadapt.nf
@@ -1,5 +1,5 @@
 // Process : Cutadapt Trim
-process cutadapt_trim {
+process trim_fixed {
     
     container "${params.container__cutadapt}"
     label "mem_medium"
@@ -16,4 +16,19 @@ process cutadapt_trim {
 
     script:
     template "cutadapt_trim.sh"
+}
+
+workflow trim {
+
+    take:
+    fastq_ch
+    prefix
+
+    main:
+
+    trim_fixed(fastq_ch, prefix)
+
+    emit:
+    trim_fixed.out
+
 }

--- a/modules/cutadapt.nf
+++ b/modules/cutadapt.nf
@@ -1,4 +1,4 @@
-// Process : Cutadapt Trim
+// Process : Cutadapt Trim - Fixed Number of Bases
 process trim_fixed {
     
     container "${params.container__cutadapt}"
@@ -18,6 +18,26 @@ process trim_fixed {
     template "cutadapt_trim.sh"
 }
 
+// Process : Cutadapt Trim - Paired Adapter Sequences
+process trim_adapters {
+    
+    container "${params.container__cutadapt}"
+    label "mem_medium"
+
+
+    publishDir "${params.output}/${prefix}/fastq/", mode: "copy", overwrite: "true"
+
+    input:
+        file(fastq)
+        val(prefix)
+        
+    output: 
+        file "${fastq.name.replaceAll(".gz","")}"
+
+    script:
+    template "cutadapt_adapters.sh"
+}
+
 workflow trim {
 
     take:
@@ -26,9 +46,27 @@ workflow trim {
 
     main:
 
-    trim_fixed(fastq_ch, prefix)
+    // If the user provided a set of paired adapter sequences
+    if ( params.paired_adapters ){
+
+        // Perform trimming using those paired adapters
+        trim_adapters(fastq_ch, prefix)
+
+        // Use the output as that process as the output of the workflow
+        trimmed_fastqs = trim_adapters.out
+
+    // If adapter sequences were not found
+    } else {
+
+        // Perform trimming using a fixed number of bases from each end
+        trim_fixed(fastq_ch, prefix)
+
+        // Use the output as that process as the output of the workflow
+        trimmed_fastqs = trim_fixed.out
+
+    }
 
     emit:
-    trim_fixed.out
+    trimmed_fastqs
 
 }

--- a/modules/cutadapt.nf
+++ b/modules/cutadapt.nf
@@ -46,10 +46,11 @@ workflow trim {
 
     main:
 
-    // If the user provided a set of paired adapter sequences
-    if ( params.paired_adapters ){
+    // If the user provided a 5' adapter sequence
+    if ( params.adapter_5_prime ){
 
         // Perform trimming using those paired adapters
+        // Also trim the read length down to params.insert_length
         trim_adapters(fastq_ch, prefix)
 
         // Use the output as that process as the output of the workflow
@@ -58,7 +59,8 @@ workflow trim {
     // If adapter sequences were not found
     } else {
 
-        // Perform trimming using a fixed number of bases from each end
+        // Perform trimming using a fixed number of bases (--trim_5_prime, defaults to 0)
+        // Also trim the read length down to params.insert_length
         trim_fixed(fastq_ch, prefix)
 
         // Use the output as that process as the output of the workflow

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,6 +5,25 @@ manifest {
     defaultBranch = 'main'
 }
 
+params {
+
+    help = false
+    scale_cutoff = 1
+    trim_3_prime = -8
+    trim_5_prime = 32
+
+    suffix_list = "trimmed gz fq fastq fna fasta"
+
+    container__pandas = "quay.io/fhcrc-microbiome/python-pandas:v1.2.1_latest"
+    container__fastqc = "quay.io/biocontainers/fastqc:0.11.9--hdfd78af_1"
+    container__multiqc = "quay.io/biocontainers/multiqc:1.11--pyhdfd78af_0"
+    container__cutadapt = "quay.io/biocontainers/cutadapt:3.4--py37h73a75cf_1"
+    container__mageck = "quay.io/biocontainers/mageck:0.5.9.4--py38h8c62d01_1"
+    container__mageckflute = "quay.io/biocontainers/bioconductor-mageckflute:1.12.0--r41hdfd78af_0"
+    container__mageckvispr = "quay.io/biocontainers/mageck-vispr:0.5.6--py_0"
+    container__rmd = "rocker/r-rmd:latest"
+
+}
 
 profiles{
     standard {

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,11 +9,9 @@ params {
 
     help = false
     scale_cutoff = 1
-    trim_3_prime = -8
-    trim_5_prime = 32
-    min_readlen = 17
-    max_readlen = 20
-    paired_adapters = false
+    insert_length = 20
+    trim_5_prime = 0
+    adapter_5_prime = false
 
     suffix_list = "trimmed gz fq fastq fna fasta"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,6 +13,7 @@ params {
     trim_5_prime = 32
     min_readlen = 17
     max_readlen = 20
+    paired_adapters = false
 
     suffix_list = "trimmed gz fq fastq fna fasta"
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,6 +11,8 @@ params {
     scale_cutoff = 1
     trim_3_prime = -8
     trim_5_prime = 32
+    min_readlen = 17
+    max_readlen = 20
 
     suffix_list = "trimmed gz fq fastq fna fasta"
 

--- a/templates/cutadapt_adapters.sh
+++ b/templates/cutadapt_adapters.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+echo FASTQ file is ${fastq.name}
+echo Adapter sequences are ${params.paired_adapters}
+
+# Parse the name of the sample from the name of the FASTQ file
+SAMPLE_NAME="${fastq.name}"
+for suffix in ${params.suffix_list}; do
+    SAMPLE_NAME=\$(echo \$SAMPLE_NAME | sed "s/.\$suffix\$//")
+done
+
+cutadapt \
+    -m ${params.min_readlen} \
+    -M ${params.max_readlen} \
+    -a ${params.paired_adapters} \
+    -o \$SAMPLE_NAME".fastq" "${fastq.name}" \
+    
+ls -lahtr

--- a/templates/cutadapt_adapters.sh
+++ b/templates/cutadapt_adapters.sh
@@ -3,7 +3,8 @@
 set -Eeuo pipefail
 
 echo FASTQ file is ${fastq.name}
-echo Adapter sequences are ${params.paired_adapters}
+echo 5-prime adapter sequence is ${params.adapter_5_prime}
+echo Trimming reads to ${params.insert_length}bp in total length
 
 # Parse the name of the sample from the name of the FASTQ file
 SAMPLE_NAME="${fastq.name}"
@@ -12,9 +13,9 @@ for suffix in ${params.suffix_list}; do
 done
 
 cutadapt \
-    -m ${params.min_readlen} \
-    -M ${params.max_readlen} \
-    -a ${params.paired_adapters} \
+    -m ${params.insert_length} \
+    -g ${params.adapter_5_prime} \
+    --length ${params.insert_length} \
     -o \$SAMPLE_NAME".fastq" "${fastq.name}" \
     
 ls -lahtr

--- a/templates/cutadapt_adapters.sh
+++ b/templates/cutadapt_adapters.sh
@@ -2,9 +2,9 @@
 
 set -Eeuo pipefail
 
-echo FASTQ file is ${fastq.name}
-echo 5-prime adapter sequence is ${params.adapter_5_prime}
-echo Trimming reads to ${params.insert_length}bp in total length
+echo "FASTQ file is ${fastq.name}"
+echo "5-prime adapter sequence is ${params.adapter_5_prime}"
+echo "Trimming reads to ${params.insert_length}bp in total length"
 
 # Parse the name of the sample from the name of the FASTQ file
 SAMPLE_NAME="${fastq.name}"

--- a/templates/cutadapt_trim.sh
+++ b/templates/cutadapt_trim.sh
@@ -2,9 +2,9 @@
 
 set -Eeuo pipefail
 
-echo FASTQ file is ${fastq.name}
-echo Removing a fixed number of bases from 5-prime (${params.trim_5_prime}bp)
-echo Trimming reads to ${params.insert_length}bp in total length
+echo "FASTQ file is ${fastq.name}"
+echo "Removing a fixed number of bases from 5-prime (${params.trim_5_prime}bp)"
+echo "Trimming reads to ${params.insert_length}bp in total length"
 
 # Parse the name of the sample from the name of the FASTQ file
 SAMPLE_NAME="${fastq.name}"

--- a/templates/cutadapt_trim.sh
+++ b/templates/cutadapt_trim.sh
@@ -13,6 +13,8 @@ for suffix in ${params.suffix_list}; do
 done
 
 cutadapt \
+    -m ${params.min_readlen} \
+    -M ${params.max_readlen} \
     -u "${params.trim_5_prime}" \
     -u "${params.trim_3_prime}" \
     -o \$SAMPLE_NAME".fastq" "${fastq.name}" \

--- a/templates/cutadapt_trim.sh
+++ b/templates/cutadapt_trim.sh
@@ -3,8 +3,8 @@
 set -Eeuo pipefail
 
 echo FASTQ file is ${fastq.name}
-echo Prime5 is ${params.trim_5_prime}
-echo Prime3 is ${params.trim_3_prime}
+echo Removing a fixed number of bases from 5-prime (${params.trim_5_prime}bp)
+echo Trimming reads to ${params.insert_length}bp in total length
 
 # Parse the name of the sample from the name of the FASTQ file
 SAMPLE_NAME="${fastq.name}"
@@ -13,10 +13,9 @@ for suffix in ${params.suffix_list}; do
 done
 
 cutadapt \
-    -m ${params.min_readlen} \
-    -M ${params.max_readlen} \
+    -m ${params.insert_length} \
     -u "${params.trim_5_prime}" \
-    -u "${params.trim_3_prime}" \
+    --length ${params.insert_length} \
     -o \$SAMPLE_NAME".fastq" "${fastq.name}" \
     
 ls -lahtr

--- a/templates/mageckvispr_export.py
+++ b/templates/mageckvispr_export.py
@@ -6,61 +6,86 @@ import os
 from vispr import Screen
 import yaml
 
-# The input files which should be present in the working directory
-# are count_normalized.txt and gene_summary.txt
-assert os.path.exists("count_normalized.txt")
-assert os.path.exists("gene_summary.txt")
 
-# Make a YAML file informing VISPR where those files are
-configpath = "config.yaml"
-with open(configpath, "w") as handle:
-    yaml.dump(
-        dict(
-            experiment="myexperiment",
-            species="homo_sapiens",
-            assembly="hg19",
-            targets=dict(results="gene_summary.txt", genes=True),
-            sgrnas=dict(counts="count_normalized.txt")
-        ),
-        handle
-    )
+def mageckvispr_export():
 
-# Use that config file to load the data
-with open(configpath) as f:
-    screen = Screen(yaml.safe_load(f), parentdir="./")
+    # The input files which should be present in the working directory
+    # are count_normalized.txt and gene_summary.txt
+    assert os.path.exists("count_normalized.txt")
+    assert os.path.exists("gene_summary.txt")
 
-def write(dat, name):
-    with open(name + ".json", "w") as out:
-        json.dump(json.loads(dat)['data'], out, indent=2)
-        logging.info(f"Error writing out data for {name}")
+    # Make a YAML file informing VISPR where those files are
+    configpath = "config.yaml"
+    with open(configpath, "w") as handle:
+        yaml.dump(
+            dict(
+                experiment="myexperiment",
+                species="homo_sapiens",
+                assembly="hg19",
+                targets=dict(results="gene_summary.txt", genes=True),
+                sgrnas=dict(counts="count_normalized.txt")
+            ),
+            handle
+        )
 
-if screen.fastqc is not None:
-    write(screen.fastqc.plot_gc_content(), "gc-content")
-    write(screen.fastqc.plot_base_quality(), "base-quality")
-    write(screen.fastqc.plot_seq_quality(), "seq-quality")
-if screen.mapstats is not None:
-    write(screen.mapstats.plot_mapstats(), "mapped-unmapped")
-    write(screen.mapstats.plot_zerocounts(), "zerocounts")
-    write(screen.mapstats.plot_gini_index(), "gini-index")
-write(screen.rnas.plot_normalization(), "readcounts")
-write(screen.rnas.plot_readcount_cdf(), "readcount-cdf")
-write(screen.rnas.plot_correlation(), "correlation")
+    # Use that config file to load the data
+    with open(configpath) as f:
 
-# Only use PCA if there are more than 2 samples
-if screen.rnas.df.shape[1] > 4:
-    write(screen.rnas.plot_pca(1, 2), "pca-1-2")
-    write(screen.rnas.plot_pca(1, 3), "pca-1-3")
-    write(screen.rnas.plot_pca(2, 3), "pca-2-3")
-
-for condition, results in screen.targets.items():
-    for selection, results in results.items():
-        pre = ".".join(([] if condition == "default" else [condition]) +
-                        [selection.replace(" ", "-")])
+        # Catch any errors encountered while parsing results
         try:
-            write(results.plot_pvals(), pre + ".p-values")
-        except:
-            logging.info("Error writing out p-values")
-        try:
-            write(results.plot_pval_hist(), pre + ".p-value-hist")
-        except:
-            logging.info("Error writing out log10-pvalues")
+            screen = Screen(yaml.safe_load(f), parentdir="./")
+
+        # If there aren't enough replicates, we may encounter the error:
+        # ValueError: zero-size array to reduction operation minimum which has no identity
+        # If so:
+        except ValueError as e:
+
+            # Log the error
+            logging.info("There was an error parsing results, stopping")
+
+            # Write out the error
+            with open("error.txt", "w") as handle:
+                handle.write(str(e))
+
+            # And stop any further processing
+            return
+
+    def write(dat, name):
+        with open(name + ".json", "w") as out:
+            json.dump(json.loads(dat)['data'], out, indent=2)
+            logging.info(f"Error writing out data for {name}")
+
+    if screen.fastqc is not None:
+        write(screen.fastqc.plot_gc_content(), "gc-content")
+        write(screen.fastqc.plot_base_quality(), "base-quality")
+        write(screen.fastqc.plot_seq_quality(), "seq-quality")
+    if screen.mapstats is not None:
+        write(screen.mapstats.plot_mapstats(), "mapped-unmapped")
+        write(screen.mapstats.plot_zerocounts(), "zerocounts")
+        write(screen.mapstats.plot_gini_index(), "gini-index")
+    write(screen.rnas.plot_normalization(), "readcounts")
+    write(screen.rnas.plot_readcount_cdf(), "readcount-cdf")
+    write(screen.rnas.plot_correlation(), "correlation")
+
+    # Only use PCA if there are more than 2 samples
+    if screen.rnas.df.shape[1] > 4:
+        write(screen.rnas.plot_pca(1, 2), "pca-1-2")
+        write(screen.rnas.plot_pca(1, 3), "pca-1-3")
+        write(screen.rnas.plot_pca(2, 3), "pca-2-3")
+
+    for condition, results in screen.targets.items():
+        for selection, results in results.items():
+            pre = ".".join(([] if condition == "default" else [condition]) +
+                            [selection.replace(" ", "-")])
+            try:
+                write(results.plot_pvals(), pre + ".p-values")
+            except:
+                logging.info("Error writing out p-values")
+            try:
+                write(results.plot_pval_hist(), pre + ".p-value-hist")
+            except:
+                logging.info("Error writing out log10-pvalues")
+
+if __name__ == "__main__":
+    mageckvispr_export()
+

--- a/templates/mageckvispr_export.py
+++ b/templates/mageckvispr_export.py
@@ -46,8 +46,11 @@ write(screen.rnas.plot_normalization(), "readcounts")
 write(screen.rnas.plot_readcount_cdf(), "readcount-cdf")
 write(screen.rnas.plot_correlation(), "correlation")
 write(screen.rnas.plot_pca(1, 2), "pca-1-2")
-write(screen.rnas.plot_pca(1, 3), "pca-1-3")
-write(screen.rnas.plot_pca(2, 3), "pca-2-3")
+
+# Only use PC3 if there are more than 2 samples
+if screen.rnas.df.shape[1] > 4:
+    write(screen.rnas.plot_pca(1, 3), "pca-1-3")
+    write(screen.rnas.plot_pca(2, 3), "pca-2-3")
 
 for condition, results in screen.targets.items():
     for selection, results in results.items():

--- a/templates/mageckvispr_export.py
+++ b/templates/mageckvispr_export.py
@@ -45,10 +45,10 @@ if screen.mapstats is not None:
 write(screen.rnas.plot_normalization(), "readcounts")
 write(screen.rnas.plot_readcount_cdf(), "readcount-cdf")
 write(screen.rnas.plot_correlation(), "correlation")
-write(screen.rnas.plot_pca(1, 2), "pca-1-2")
 
-# Only use PC3 if there are more than 2 samples
+# Only use PCA if there are more than 2 samples
 if screen.rnas.df.shape[1] > 4:
+    write(screen.rnas.plot_pca(1, 2), "pca-1-2")
     write(screen.rnas.plot_pca(1, 3), "pca-1-3")
     write(screen.rnas.plot_pca(2, 3), "pca-2-3")
 


### PR DESCRIPTION
This PR contains updates which modify the way in which adapter trimming is performed. 

The new approach will use a 5' adapter and a fixed insert length, rather than trimming a fixed number of bases from each end.

The PCA bug was found with datasets that only have 2 FASTQ files, and is now fixed.